### PR TITLE
Correctly disabling `flycheck-eglot-mode` when the buffer is killed

### DIFF
--- a/flycheck-eglot.el
+++ b/flycheck-eglot.el
@@ -209,30 +209,27 @@ DIAGS is the Eglot diagnostics list in Flymake format."
 (defun flycheck-eglot--setup ()
   "Setup flycheck-eglot."
   (when (flycheck-eglot--eglot-available-p)
-    (add-to-list 'flycheck-checkers 'eglot-check)
-    (setq flycheck-disabled-checkers
-          (remove 'eglot-check
-                  flycheck-disabled-checkers))
-    (let ((current-checker (flycheck-get-checker-for-buffer)))
-      (flycheck-add-mode 'eglot-check major-mode)
-      (if (or flycheck-eglot-exclusive
-              (null current-checker))
-          (setq flycheck-checker 'eglot-check)
-        (unless (eq current-checker 'eglot-check)
-          (flycheck-add-next-checker 'eglot-check current-checker))))
+    (flycheck-eglot--register-eglot-checker major-mode)
+    (setq flycheck-checker 'eglot-check)
     (eglot-flymake-backend #'flycheck-eglot--report-eglot-diagnostics)
     (flymake-mode -1)
     (flycheck-mode 1)))
 
+(defun flycheck-eglot--register-eglot-checker (mode)
+  (add-to-list 'flycheck-checkers 'eglot-check t)
+  (unless (member mode (flycheck-checker-get 'eglot-check 'modes))
+    (flycheck-add-mode 'eglot-check mode))
+  (if flycheck-eglot-exclusive
+      (setf (flycheck-checker-get 'eglot-check 'next-checkers) nil)
+    (cl-loop for checker in flycheck-checkers
+             when (flycheck-checker-supports-major-mode-p checker mode)
+             do (flycheck-add-next-checker 'eglot-check checker) (cl-return))))
 
 (defun flycheck-eglot--teardown ()
   "Teardown flycheck-eglot."
   (when (flycheck-eglot--eglot-available-p)
     (eglot-flymake-backend #'ignore)
     (setq flycheck-checker nil)
-    (setq flycheck-disabled-checkers
-          (cl-adjoin 'eglot-check
-                     flycheck-disabled-checkers))
     (setq flycheck-eglot--current-errors nil)
     (flycheck-buffer-deferred)))
 


### PR DESCRIPTION
Append eglot-check instead of setting disabled checkers.

When `flycheck-eglot-mode` is disabled in the buffer, the checker `eglot-check` should not take effects. Adding it to the disabled checker list is a good idea, however, there's no guarantee that the user has chance to call `flycheck-eglot--teardown`, I mean, to toggle `flycheck-eglot-mode` before they kill the buffer.

As a result, `eglot-check` remains at the begining of `flycheck-checkers`, which will be selected by flycheck next time when the user change to the same major mode. Even worse, if the user has set `flycheck-eglot-exclusive`, the other checkers have no chances to run. And eglot provides no linting diagnostic if `flycheck-eglot-mode` is disabled, which is not a desired situation.

In fact, I think the buffer-local mode `flycheck-eglot-mode` should not modify any global variables to achieve the expected states, in this case, `flycheck-disabled-checkers` and `flycheck-checkers`.

The workaround here:
- Define a new function `flycheck-eglot--register-eglot-checker`, which register `elgot-check` as a valid flycheck checker. The register routine is idempotent.
- It appends `eglot-check` **in the end** of `flycheck-checkers`. As a result, it will not be selected as the default checker by flycheck.
- If the user has not set `flycheck-eglot-exclusive`, add the first valid checker for the major mode to the next checker of `eglot-checker`.
- When `flycheck-eglot-mode` is enabled, always set the buffer-local `flycheck-checker` to `eglot-check`. Therefore, it will always be run at first, and depending on `flycheck-eglot-exclusive`, flycheck may or may not select the next checker(s).