### PR TITLE
Fix changes to eglot--diagnostics

### DIFF
--- a/flycheck-eglot.el
+++ b/flycheck-eglot.el
@@ -218,7 +218,8 @@ ORIG is the original function, (BEG END) is the range"
                                        end))
                               (beg (= beg (flymake-diagnostic-beg s)))
                               (t t)))
-                      eglot--diagnostics)))
+                      ;; `eglot--diagnostics' was a list before, but it is now a cons after Emacs 31.
+                      (if (consp eglot--diagnostics) (car eglot--diagnostics) eglot--diagnostics))))
 
 
 (defun flycheck-eglot--setup ()


### PR DESCRIPTION
According to [this change in emacs master](https://github.com/emacs-mirror/emacs/commit/7ae275f04c46e1724fafd8c8aa2f3eed5771df1c#diff-a58ee72581752df2d94e2bf2cdfe3ff4d094478433802adb513afbd4c3d07f9fR2271), `eglot--diagnostics` is now a `cons`, not a `list`.

Also based on https://github.com/konrad1977/flycheck-eglot/commit/90bd5cfe2accd854bf0611eeec8c8cc0f9409763.