### PR TITLE
fix(eglot): Handle empty diagnostics from Eglot

### DIFF
--- a/flycheck-eglot.el
+++ b/flycheck-eglot.el
@@ -219,7 +219,10 @@ ORIG is the original function, (BEG END) is the range"
                               (beg (= beg (flymake-diagnostic-beg s)))
                               (t t)))
                       ;; `eglot--diagnostics' was a list before, but it is now a cons after Emacs 31.
-                      (if (proper-list-p eglot--diagnostics) eglot--diagnostics (car eglot--diagnostics)))))
+                      (pcase (if (proper-list-p eglot--diagnostics) eglot--diagnostics (car eglot--diagnostics))
+                        (`nil nil)
+                        (`(nil) nil)
+                        (other other)))))
 
 
 (defun flycheck-eglot--setup ()


### PR DESCRIPTION
Eglot can return `nil` (before Emacs 31) or `(nil . nil)` (after Emacs 31) as its list of diagnostics. `(nil . nil)` would resolve to `(nil)` which is treated as `proper-list-p`. These values were not properly handled and could lead to errors in Flycheck.

This change uses a `pcase` statement to explicitly filter out these empty or nil-containing lists, preventing potential errors.