### PR TITLE
fix: Adapt to new eglot--diagnostics structure

### DIFF
--- a/flycheck-eglot.el
+++ b/flycheck-eglot.el
@@ -218,8 +218,11 @@ ORIG is the original function, (BEG END) is the range"
                                        end))
                               (beg (= beg (flymake-diagnostic-beg s)))
                               (t t)))
-                      ;; `eglot--diagnostics' was a list before, but it is now a cons after Emacs 31.
+                      ;; `eglot--diagnostics' was a list before,
+                      ;; but it is now wrapped in a list as of 4aff16bf9e8be9e45b5ac5b98a323957e3af6444
+                      ;; in https://github.com/emacs-mirror/emacs/.
                       (pcase eglot--diagnostics
+                        (`(,(pred proper-list-p) ,_ ,_) (car eglot--diagnostics))
                         (`(nil) nil)
                         ((pred proper-list-p) eglot--diagnostics)
                         (_ (car eglot--diagnostics))))))


### PR DESCRIPTION
The structure of the `eglot--diagnostics` variable changed in recent Emacs development builds (commit https://github.com/emacs-mirror/emacs/commit/4aff16bf9e8be9e45b5ac5b98a323957e3af6444). The list of diagnostics is now wrapped inside another list instead of a cons in pevious version.

This commit updates the `pcase` to handle this new data structure, ensuring compatibility with upcoming Emacs versions.