### PR TITLE
fix(eglot): Adapt to removal of eglot--diagnostics variable

### DIFF
--- a/flycheck-eglot.el
+++ b/flycheck-eglot.el
@@ -218,14 +218,24 @@ ORIG is the original function, (BEG END) is the range"
                                        end))
                               (beg (= beg (flymake-diagnostic-beg s)))
                               (t t)))
-                      ;; `eglot--diagnostics' was a list before,
-                      ;; but it is now wrapped in a list as of 4aff16bf9e8be9e45b5ac5b98a323957e3af6444
-                      ;; in https://github.com/emacs-mirror/emacs/.
-                      (pcase eglot--diagnostics
-                        (`(,(pred proper-list-p) ,_ ,_) (car eglot--diagnostics))
-                        (`(nil) nil)
-                        ((pred proper-list-p) eglot--diagnostics)
-                        (_ (car eglot--diagnostics))))))
+                      (cond ((boundp 'eglot--diagnostics)
+                             ;; `eglot--diagnostics' was a list before,
+                             ;; but it is now wrapped in a list as of 4aff16bf9e8be9e45b5ac5b98a323957e3af6444
+                             ;; in https://github.com/emacs-mirror/emacs/.
+                             (pcase eglot--diagnostics
+                               (`(,(pred proper-list-p) ,_ ,_) (car eglot--diagnostics))
+                               (`(nil) nil)
+                               ((pred proper-list-p) eglot--diagnostics)
+                               (_ (car eglot--diagnostics))))
+
+                            ;; if eglot--diagnostics is not bound, it's most likely
+                            ;; removed as of da4c693e0be6ede3f245d29ad67d0dfc64c5656b
+                            ;; in https://github.com/emacs-mirror/emacs
+                            ;;
+                            ;; The diagnostics are present in `eglot--pushed-diagnostics`
+                            ;; and `eglot--pulled-diagnostics` or maybe both.
+                            ((and (boundp 'eglot--pushed-diagnostics) (boundp 'eglot--pulled-diagnostics))
+                             (append (car eglot--pushed-diagnostics) (car eglot--pulled-diagnostics)))))))
 
 
 (defun flycheck-eglot--setup ()


### PR DESCRIPTION
The internal variable `eglot--diagnostics` was removed in [recent versions of Eglot][1]. Diagnostics are now split between `eglot--pushed-diagnostics` and `eglot--pulled-diagnostics`.

This change fetches diagnostics from these new variables when the old one is not available, ensuring compatibility with newer Eglot versions.

[1]: https://github.com/emacs-mirror/emacs/commit/da4c693e0be6ede3f245d29ad67d0dfc64c5656b