### PR TITLE
Gate pull diagnostics on :diagnosticProvider capability

### DIFF
--- a/flycheck-eglot.el
+++ b/flycheck-eglot.el
@@ -268,6 +268,12 @@ ORIG is the original function, (BEG END) is the range"
   (when (flycheck-eglot--eglot-available-p)
     (flycheck-eglot--register-eglot-checker major-mode)
     (setq flycheck-checker 'eglot-check)
+    ;; Auto-detect pull diagnostic support once at setup time.
+    ;; `eglot-flymake-backend' already checks this internally, but
+    ;; doing it here avoids the overhead of calling the backend on
+    ;; every flycheck cycle for push-only servers.
+    (unless (eglot-server-capable :diagnosticProvider)
+      (setq flycheck-eglot--can-run-flymake-backend-p nil))
     (eglot-flymake-backend #'flycheck-eglot--report-eglot-diagnostics)
     (advice-add #'flymake-diagnostics :around #'flycheck-eglot--flymake-diagnostics-wrapper)
     (flymake-mode -1)


### PR DESCRIPTION
## Summary

- Auto-detect `:diagnosticProvider` capability once in `--setup` and disable pull for push-only servers
- `eglot-flymake-backend` already checks this internally, so the one-time detection avoids the overhead of calling the backend on every flycheck cycle when pull isn't supported
- Manual overrides via `flycheck-eglot-enable-diagnostics-pull` / `flycheck-eglot-disable-diagnostics-pull` still take effect (they set the variable after setup)

## Context

Follow-up to #17 and the pull-based diagnostics support in d073b24. As discussed in [#17 (comment)](https://github.com/flycheck/flycheck-eglot/pull/17#issuecomment-3937966650), the push/pull distinction matters for how `flycheck-check-syntax-automatically` interacts with diagnostics.

## Test plan

- [ ] Push-only LSP (e.g. pyright): verify diagnostics still display correctly via push path, and that `flycheck-eglot--can-run-flymake-backend-p` is nil after setup
- [ ] Pull-capable LSP (e.g. ty): verify pull diagnostics work, and that `flycheck-eglot--can-run-flymake-backend-p` remains t
- [ ] Manual `flycheck-eglot-disable-diagnostics-pull` after setup: verify it still works
- [ ] Manual `flycheck-eglot-enable-diagnostics-pull` to force-enable pull on a push-only server: verify it overrides the auto-detection

---

- [x] This PR contains AI-generated work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)