### PR TITLE
Add a deprecation notice for Flycheck 38 and newer

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,6 +2,24 @@
 #+AUTHOR: Sergey Firsov <intramurz@gmail.com>
 [[https://melpa.org/#/flycheck-eglot][file:https://melpa.org/packages/flycheck-eglot-badge.svg]]     [[https://stable.melpa.org/#/flycheck-eglot][file:https://stable.melpa.org/packages/flycheck-eglot-badge.svg]]
 
+#+begin_quote
+*This package is deprecated.  If you run Flycheck 38 or newer, uninstall it.*
+
+Flycheck 38 ships an Eglot bridge out of the box, and it deliberately uses
+the same mode names this package defined - =flycheck-eglot-mode= and
+=global-flycheck-eglot-mode= - so having both installed makes them clash.
+Remove flycheck-eglot from your config, and the same setup keeps working
+against the built-in implementation:
+
+#+begin_src elisp
+(global-flycheck-eglot-mode)
+#+end_src
+
+The built-in bridge also understands the Emacs 31 pull-diagnostics model
+and offers the server's quickfix code actions as Flycheck fixes.
+On Flycheck 37 or older this package still works; upgrade when you can.
+#+end_quote
+
 A simple "glue" minor mode that allows [[https://www.flycheck.org/][Flycheck]] and [[https://github.com/joaotavora/eglot][Eglot]] to work together. Thus, the Flycheck frontend can display the results of syntactic checks performed by the LSP server.
 
 * Install

--- a/flycheck-eglot.el
+++ b/flycheck-eglot.el
@@ -45,6 +45,10 @@
 
 ;;; Commentary:
 
+;; This package is deprecated for Flycheck 38 and newer, which ship a
+;; built-in Eglot bridge under the same mode names; running both makes
+;; them clash.  See the README for migration.
+
 ;; A simple "glue" minor mode that allows Flycheck and Eglot to work together.
 ;;
 ;; You just need to enable `global-flycheck-eglot-mode'.


### PR DESCRIPTION
Hi Sergey - as of Flycheck 38 there's a built-in Eglot bridge, and it deliberately reuses this package's mode names so existing configs keep working after migration. The flip side is that having both installed makes them clash, which is already biting users on 38+.

This adds a notice to the README and Commentary pointing 38+ users at the built-in mode, while making clear the package still works fine on 37 and older. Entirely your call how you want to handle the package's future - happy to adjust the wording, and thank you for building this; the built-in bridge exists because your package proved how much people wanted it.